### PR TITLE
fix(middleware): adicionar verificação de cabeçalho de autorização no verifyJwt

### DIFF
--- a/src/http/middlewares/verify-jwt.ts
+++ b/src/http/middlewares/verify-jwt.ts
@@ -2,8 +2,15 @@ import { FastifyReply, FastifyRequest } from 'fastify'
 
 export async function verifyJwt(request: FastifyRequest, reply: FastifyReply) {
   try {
+
+    const authHeader = request.headers.authorization
+    if (!authHeader) {
+      return reply.status(401).send({ message: 'Token não fornecido.' })
+    }
+
     await request.jwtVerify()
   } catch (err) {
     return reply.status(401).send({ message: 'Unauthorized.' })
   }
 }
+


### PR DESCRIPTION
### **Correção do Middleware de Autenticação JWT**
Correção aplicada:
Adicionada verificação explícita para cabeçalhos de autorização ausentes
A estrutura do middleware agora garante que todas as requisições sem token serão bloqueadas, não apenas as que possuem token inválido